### PR TITLE
Fix `unused_qualifications` warning on nightly

### DIFF
--- a/enumflags_derive/src/lib.rs
+++ b/enumflags_derive/src/lib.rs
@@ -239,8 +239,8 @@ fn check_flag(type_name: &Ident, flag: &Flag, bits: u8) -> Result<Option<TokenSt
                 const _:
                     <<[(); (
                         (#type_name::#variant_name as u128).is_power_of_two()
-                    ) as usize] as enumflags2::_internal::AssertionHelper>
-                        ::Status as enumflags2::_internal::ExactlyOneBitSet>::X
+                    ) as usize] as ::enumflags2::_internal::AssertionHelper>
+                        ::Status as ::enumflags2::_internal::ExactlyOneBitSet>::X
                     = ();
             )))
         }

--- a/test_suite/ui/invalid_attribute_syntax.rs
+++ b/test_suite/ui/invalid_attribute_syntax.rs
@@ -1,3 +1,6 @@
+extern crate enumflags2;
+extern crate core;
+
 use enumflags2::bitflags;
 
 #[bitflags(default = A + B)]

--- a/test_suite/ui/invalid_attribute_syntax.stderr
+++ b/test_suite/ui/invalid_attribute_syntax.stderr
@@ -1,35 +1,35 @@
 error: expected `|`
- --> $DIR/invalid_attribute_syntax.rs:3:24
+ --> ui/invalid_attribute_syntax.rs:6:24
   |
-3 | #[bitflags(default = A + B)]
+6 | #[bitflags(default = A + B)]
   |                        ^
 
 error: unexpected end of input, expected identifier
- --> $DIR/invalid_attribute_syntax.rs:9:1
-  |
-9 | #[bitflags(default = A |)]
-  | ^^^^^^^^^^^^^^^^^^^^^^^^^^
-  |
-  = note: this error originates in the attribute macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
+  --> ui/invalid_attribute_syntax.rs:12:1
+   |
+12 | #[bitflags(default = A |)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = note: this error originates in the attribute macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: unexpected end of input, expected identifier
-  --> $DIR/invalid_attribute_syntax.rs:15:1
+  --> ui/invalid_attribute_syntax.rs:18:1
    |
-15 | #[bitflags(default =)]
+18 | #[bitflags(default =)]
    | ^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected `=`
-  --> $DIR/invalid_attribute_syntax.rs:21:1
+  --> ui/invalid_attribute_syntax.rs:24:1
    |
-21 | #[bitflags(default)]
+24 | #[bitflags(default)]
    | ^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `bitflags` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: expected `default`
-  --> $DIR/invalid_attribute_syntax.rs:27:12
+  --> ui/invalid_attribute_syntax.rs:30:12
    |
-27 | #[bitflags(yes)]
+30 | #[bitflags(yes)]
    |            ^^^

--- a/test_suite/ui/invalid_name_in_default.rs
+++ b/test_suite/ui/invalid_name_in_default.rs
@@ -1,3 +1,6 @@
+extern crate enumflags2;
+extern crate core;
+
 use enumflags2::bitflags;
 
 #[bitflags(default = A | C)]

--- a/test_suite/ui/invalid_name_in_default.stderr
+++ b/test_suite/ui/invalid_name_in_default.stderr
@@ -1,11 +1,11 @@
 error[E0599]: no variant or associated item named `C` found for enum `Test` in the current scope
- --> ui/invalid_name_in_default.rs:3:26
+ --> ui/invalid_name_in_default.rs:6:26
   |
-3 | #[bitflags(default = A | C)]
+6 | #[bitflags(default = A | C)]
   |                          ^
   |                          |
   |                          variant or associated item not found in `Test`
   |                          help: there is a variant with a similar name: `A`
 ...
-6 | enum Test {
+9 | enum Test {
   | --------- variant or associated item `C` not found for this enum

--- a/test_suite/ui/invalid_repr.rs
+++ b/test_suite/ui/invalid_repr.rs
@@ -1,3 +1,6 @@
+extern crate enumflags2;
+extern crate core;
+
 #[enumflags2::bitflags]
 #[repr(C)]
 #[derive(Clone, Copy)]

--- a/test_suite/ui/invalid_repr.stderr
+++ b/test_suite/ui/invalid_repr.stderr
@@ -1,17 +1,17 @@
 error: repr must be an integer type for #[bitflags].
- --> $DIR/invalid_repr.rs:2:8
+ --> ui/invalid_repr.rs:5:8
   |
-2 | #[repr(C)]
+5 | #[repr(C)]
   |        ^
 
 error: Signed types in a repr are not supported.
-  --> $DIR/invalid_repr.rs:10:8
+  --> ui/invalid_repr.rs:13:8
    |
-10 | #[repr(i32)]
+13 | #[repr(i32)]
    |        ^^^
 
 error: #[repr(usize)] is not supported. Use u32 or u64 instead.
-  --> $DIR/invalid_repr.rs:18:8
+  --> ui/invalid_repr.rs:21:8
    |
-18 | #[repr(usize)]
+21 | #[repr(usize)]
    |        ^^^^^

--- a/test_suite/ui/multiple_bits.rs
+++ b/test_suite/ui/multiple_bits.rs
@@ -1,3 +1,6 @@
+extern crate enumflags2;
+extern crate core;
+
 #[enumflags2::bitflags]
 #[repr(u8)]
 #[derive(Copy, Clone)]

--- a/test_suite/ui/multiple_bits.stderr
+++ b/test_suite/ui/multiple_bits.stderr
@@ -1,5 +1,5 @@
 error: Flags must have exactly one set bit
- --> $DIR/multiple_bits.rs:6:5
+ --> ui/multiple_bits.rs:9:5
   |
-6 |     MultipleBits = 6,
+9 |     MultipleBits = 6,
   |     ^^^^^^^^^^^^^^^^

--- a/test_suite/ui/multiple_bits_deferred.rs
+++ b/test_suite/ui/multiple_bits_deferred.rs
@@ -1,3 +1,6 @@
+extern crate enumflags2;
+extern crate core;
+
 const THREE: u8 = 3;
 
 #[enumflags2::bitflags]

--- a/test_suite/ui/multiple_bits_deferred.stderr
+++ b/test_suite/ui/multiple_bits_deferred.stderr
@@ -1,7 +1,7 @@
 error[E0277]: the trait bound `AssertionFailed: ExactlyOneBitSet` is not satisfied
- --> ui/multiple_bits_deferred.rs:7:5
-  |
-7 |     Three = THREE,
-  |     ^^^^^^^^^^^^^ the trait `ExactlyOneBitSet` is not implemented for `AssertionFailed`
-  |
-  = help: the trait `ExactlyOneBitSet` is implemented for `AssertionSucceeded`
+  --> ui/multiple_bits_deferred.rs:10:5
+   |
+10 |     Three = THREE,
+   |     ^^^^^^^^^^^^^ the trait `ExactlyOneBitSet` is not implemented for `AssertionFailed`
+   |
+   = help: the trait `ExactlyOneBitSet` is implemented for `AssertionSucceeded`

--- a/test_suite/ui/not_enum.rs
+++ b/test_suite/ui/not_enum.rs
@@ -1,3 +1,6 @@
+extern crate enumflags2;
+extern crate core;
+
 #[enumflags2::bitflags]
 #[derive(Copy, Clone)]
 struct Foo(u16);

--- a/test_suite/ui/not_enum.stderr
+++ b/test_suite/ui/not_enum.stderr
@@ -1,12 +1,12 @@
 error: #[bitflags] requires an enum
- --> $DIR/not_enum.rs:2:1
+ --> ui/not_enum.rs:5:1
   |
-2 | / #[derive(Copy, Clone)]
-3 | | struct Foo(u16);
+5 | / #[derive(Copy, Clone)]
+6 | | struct Foo(u16);
   | |________________^
 
 error: #[bitflags] requires an enum
- --> $DIR/not_enum.rs:6:1
+ --> ui/not_enum.rs:9:1
   |
-6 | const WTF: u8 = 42;
+9 | const WTF: u8 = 42;
   | ^^^^^^^^^^^^^^^^^^^

--- a/test_suite/ui/overlapping_flags.rs
+++ b/test_suite/ui/overlapping_flags.rs
@@ -1,3 +1,6 @@
+extern crate enumflags2;
+extern crate core;
+
 #[enumflags2::bitflags]
 #[repr(u8)]
 #[derive(Copy, Clone)]

--- a/test_suite/ui/overlapping_flags.stderr
+++ b/test_suite/ui/overlapping_flags.stderr
@@ -1,9 +1,9 @@
 error[E0081]: discriminant value `1` assigned more than once
- --> ui/overlapping_flags.rs:4:1
+ --> ui/overlapping_flags.rs:7:1
   |
-4 | enum Foo {
+7 | enum Foo {
   | ^^^^^^^^
-5 |     SomeFlag = 1 << 0,
+8 |     SomeFlag = 1 << 0,
   |                ------ `1` assigned here
-6 |     OverlappingFlag = 1 << 0,
+9 |     OverlappingFlag = 1 << 0,
   |                       ------ `1` assigned here

--- a/test_suite/ui/shift_out_of_range.rs
+++ b/test_suite/ui/shift_out_of_range.rs
@@ -1,3 +1,6 @@
+extern crate enumflags2;
+extern crate core;
+
 #[enumflags2::bitflags]
 #[repr(u64)]
 #[derive(Copy, Clone)]

--- a/test_suite/ui/shift_out_of_range.stderr
+++ b/test_suite/ui/shift_out_of_range.stderr
@@ -1,29 +1,29 @@
 error: Flag value out of range for u64
- --> $DIR/shift_out_of_range.rs:5:5
+ --> ui/shift_out_of_range.rs:8:5
   |
-5 |     BigNumber = 1 << 69,
+8 |     BigNumber = 1 << 69,
   |     ^^^^^^^^^^^^^^^^^^^
 
 error: Flag value out of range for u16
-  --> $DIR/shift_out_of_range.rs:12:5
+  --> ui/shift_out_of_range.rs:15:5
    |
-12 |     BigNumber = 1 << 20,
+15 |     BigNumber = 1 << 20,
    |     ^^^^^^^^^^^^^^^^^^^
 
 error: Flag value out of range for u16
-  --> $DIR/shift_out_of_range.rs:19:5
+  --> ui/shift_out_of_range.rs:22:5
    |
-19 |     BigNumber = (1 << 10) << 10,
+22 |     BigNumber = (1 << 10) << 10,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0080]: evaluation of constant value failed
- --> $DIR/shift_out_of_range.rs:5:17
+ --> ui/shift_out_of_range.rs:8:17
   |
-5 |     BigNumber = 1 << 69,
+8 |     BigNumber = 1 << 69,
   |                 ^^^^^^^ attempt to shift left by `69_i32`, which would overflow
 
 error[E0080]: evaluation of constant value failed
-  --> $DIR/shift_out_of_range.rs:12:17
+  --> ui/shift_out_of_range.rs:15:17
    |
-12 |     BigNumber = 1 << 20,
+15 |     BigNumber = 1 << 20,
    |                 ^^^^^^^ attempt to shift left by `20_i32`, which would overflow

--- a/test_suite/ui/sneaky_make_bitflags.rs
+++ b/test_suite/ui/sneaky_make_bitflags.rs
@@ -1,3 +1,6 @@
+extern crate enumflags2;
+extern crate core;
+
 use enumflags2::{bitflags, make_bitflags};
 
 #[bitflags]

--- a/test_suite/ui/sneaky_make_bitflags.stderr
+++ b/test_suite/ui/sneaky_make_bitflags.stderr
@@ -1,7 +1,7 @@
 error[E0308]: mismatched types
-  --> ui/sneaky_make_bitflags.rs:16:13
+  --> ui/sneaky_make_bitflags.rs:19:13
    |
-16 |     let x = make_bitflags!(Test::{C});
+19 |     let x = make_bitflags!(Test::{C});
    |             ^^^^^^^^^^^^^^^^^^^^^^^^^
    |             |
    |             expected `Test`, found `u8`

--- a/test_suite/ui/with_fields.rs
+++ b/test_suite/ui/with_fields.rs
@@ -1,3 +1,6 @@
+extern crate enumflags2;
+extern crate core;
+
 #[enumflags2::bitflags]
 #[repr(u8)]
 #[derive(Copy, Clone)]

--- a/test_suite/ui/with_fields.stderr
+++ b/test_suite/ui/with_fields.stderr
@@ -1,5 +1,5 @@
 error: Bitflag variants cannot contain additional data
- --> $DIR/with_fields.rs:5:8
+ --> ui/with_fields.rs:8:8
   |
-5 |     Bar(u32),
+8 |     Bar(u32),
   |        ^^^^^

--- a/test_suite/ui/zero_disciminant.rs
+++ b/test_suite/ui/zero_disciminant.rs
@@ -1,3 +1,6 @@
+extern crate enumflags2;
+extern crate core;
+
 #[enumflags2::bitflags]
 #[repr(u8)]
 #[derive(Copy, Clone)]

--- a/test_suite/ui/zero_disciminant.stderr
+++ b/test_suite/ui/zero_disciminant.stderr
@@ -1,5 +1,5 @@
 error: Flags must have exactly one set bit
- --> $DIR/zero_disciminant.rs:5:5
+ --> ui/zero_disciminant.rs:8:5
   |
-5 |     Zero = 0,
+8 |     Zero = 0,
   |     ^^^^^^^^

--- a/test_suite/ui/zero_discriminant_deferred.rs
+++ b/test_suite/ui/zero_discriminant_deferred.rs
@@ -1,3 +1,6 @@
+extern crate enumflags2;
+extern crate core;
+
 const ZERO: u8 = 0;
 
 #[enumflags2::bitflags]

--- a/test_suite/ui/zero_discriminant_deferred.stderr
+++ b/test_suite/ui/zero_discriminant_deferred.stderr
@@ -1,15 +1,15 @@
 error[E0277]: the trait bound `AssertionFailed: ExactlyOneBitSet` is not satisfied
- --> ui/zero_discriminant_deferred.rs:7:5
-  |
-7 |     Zero = ZERO,
-  |     ^^^^^^^^^^^ the trait `ExactlyOneBitSet` is not implemented for `AssertionFailed`
-  |
-  = help: the trait `ExactlyOneBitSet` is implemented for `AssertionSucceeded`
+  --> ui/zero_discriminant_deferred.rs:10:5
+   |
+10 |     Zero = ZERO,
+   |     ^^^^^^^^^^^ the trait `ExactlyOneBitSet` is not implemented for `AssertionFailed`
+   |
+   = help: the trait `ExactlyOneBitSet` is implemented for `AssertionSucceeded`
 
 error[E0277]: the trait bound `AssertionFailed: ExactlyOneBitSet` is not satisfied
-  --> ui/zero_discriminant_deferred.rs:14:5
+  --> ui/zero_discriminant_deferred.rs:17:5
    |
-14 |     Overflown = (ZERO + 2) << 7,
+17 |     Overflown = (ZERO + 2) << 7,
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `ExactlyOneBitSet` is not implemented for `AssertionFailed`
    |
    = help: the trait `ExactlyOneBitSet` is implemented for `AssertionSucceeded`


### PR DESCRIPTION
Happens when using glob import `use enumflags2::*`